### PR TITLE
Add path to error message when field or type  with no descrition is added

### DIFF
--- a/schemadiff/validation_rules/__init__.py
+++ b/schemadiff/validation_rules/__init__.py
@@ -66,7 +66,8 @@ class AddTypeWithoutDescription(ValidationRule):
 
     @property
     def message(self):
-        return f"{self.change.message} without a description for the type or one of its fields (rule: `{self.name}`)"
+        return f"{self.change.message} without a description for the type or one of its fields (rule: `{self.name}`). " \
+               f"Path {self.change.path}."
 
 
 class RemoveTypeDescription(ValidationRule):
@@ -78,7 +79,7 @@ class RemoveTypeDescription(ValidationRule):
         if isinstance(self.change, TypeDescriptionChanged):
             return self.change.new_desc not in (None, "")
         return True
-    
+
     @property
     def message(self):
         return (
@@ -95,10 +96,10 @@ class AddFieldWithoutDescription(ValidationRule):
         if isinstance(self.change, ObjectTypeFieldAdded):
             return self.change.description not in (None, "")
         return True
-    
+
     @property
     def message(self):
-        return f"{self.change.message} without a description (rule: `{self.name}`)"
+        return f"{self.change.message} without a description (rule: `{self.name}`). Path {self.change.path}"
 
 
 class RemoveFieldDescription(ValidationRule):

--- a/schemadiff/validation_rules/__init__.py
+++ b/schemadiff/validation_rules/__init__.py
@@ -66,8 +66,7 @@ class AddTypeWithoutDescription(ValidationRule):
 
     @property
     def message(self):
-        return f"{self.change.message} without a description for the type or one of its fields (rule: `{self.name}`). " \
-               f"Path {self.change.path}."
+        return f"{self.change.message} without a description for {self.change.path} (rule: `{self.name}`)."
 
 
 class RemoveTypeDescription(ValidationRule):
@@ -99,7 +98,7 @@ class AddFieldWithoutDescription(ValidationRule):
 
     @property
     def message(self):
-        return f"{self.change.message} without a description (rule: `{self.name}`). Path {self.change.path}"
+        return f"{self.change.message} without a description for {self.change.path} (rule: `{self.name}`)."
 
 
 class RemoveFieldDescription(ValidationRule):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,16 +140,16 @@ def test_schema_rules_mode(capsys):
 
     stdout = capsys.readouterr()
 
-    assert "⛔ Type `NewTypeWithoutDesc` was added without a description for the type or one of its fields " \
+    assert "⛔ Type `NewTypeWithoutDesc` was added without a description for NewTypeWithoutDesc " \
            "(rule: `add-type-without-description`)" in stdout.out
-    assert "⛔ Type `NewEnumWithoutDesc` was added without a description for the type or one of its fields " \
+    assert "⛔ Type `NewEnumWithoutDesc` was added without a description for NewEnumWithoutDesc " \
            "(rule: `add-type-without-description`)" in stdout.out
     assert "⛔ Description for type `Field` was removed " \
            "(rule: `remove-type-description`)" in stdout.out
     assert "⛔ `Field.calculus` description was removed " \
            "(rule: `remove-field-description`)" in stdout.out
-    assert "⛔ Field `c` was added to object type `Query` without a description " \
-           "(rule: `add-field-without-description`)" in stdout.out
+    assert "⛔ Field `c` was added to object type `Query` without a description for " \
+           "Query.c (rule: `add-field-without-description`)" in stdout.out
     assert "⛔ Enum value `VALUE_3` was added to `Enum` enum without a description " \
            "(rule: `add-enum-value-without-description`)" in stdout.out
     assert "⛔ Description for enum value `VALUE_2` was removed " \

--- a/tests/test_validation_rules.py
+++ b/tests/test_validation_rules.py
@@ -70,8 +70,8 @@ def test_type_added_with_desc_but_missing_desc_on_its_fields():
     diff = Schema(a, b).diff()
     assert AddTypeWithoutDescription(diff[0]).is_valid() is False
     assert AddTypeWithoutDescription(diff[0]).message == (
-        'Type `NewType` was added without a description for the type or one of its fields (rule: '
-        '`add-type-without-description`). Path NewType.'
+        'Type `NewType` was added without a description for NewType (rule: '
+        '`add-type-without-description`).'
     )
 
 


### PR DESCRIPTION
When a field or a new type is added without a description, an error message is displayed. This add the path to that field or type in the message, so it is easily spotted.