### PR TITLE
Fix installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,6 @@ dev = [
     "pdoc3==0.9.1",
     "hatch",
 ]
+
+[tool.hatch.build.targets.wheel]
+packages = ["schemadiff"]


### PR DESCRIPTION
This pull request makes a small configuration change to the `pyproject.toml` file, specifically related to packaging with Hatch.

* Added a `[tool.hatch.build.targets.wheel]` section to specify that the `schemadiff` package should be included when building a wheel distribution.